### PR TITLE
use img-thumbnail for avatar

### DIFF
--- a/themes/hugo-nanx2021/layouts/partials/header.html
+++ b/themes/hugo-nanx2021/layouts/partials/header.html
@@ -6,7 +6,7 @@
                     <div class="flex-shrink-0">
                         {{ if .Site.Params.logofile }}
                         <a href="{{ .Site.BaseURL }}">
-                            <img class="logo img-fluid d-block rounded-circle"
+                            <img class="logo img-fluid d-block rounded-circle img-thumbnail"
                                 src="{{ .Site.Params.logofile | absURL }}" alt="{{ .Site.Params.logoalt }}">
                         </a>
                         {{ end }}


### PR DESCRIPTION
The class `img-thumbnail` adds a light gray border to the image, which might make the avatar more distinctive from the page background.

https://getbootstrap.com/docs/5.0/content/images/#image-thumbnails